### PR TITLE
Add watchOS minimum version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Shapes",
     platforms: [
-        .iOS(.v13), .macOS(.v10_15)
+        .iOS(.v13), .macOS(.v10_15), .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
Without specifying the minimum version for watchOS in the package manifest it's failing to compile, even with the project's target set to watchOS 6.